### PR TITLE
Improved performance for ToUTM conversions

### DIFF
--- a/OpenStreetMap_Engine/Convert/ToUTMPoint.cs
+++ b/OpenStreetMap_Engine/Convert/ToUTMPoint.cs
@@ -49,12 +49,13 @@ namespace BH.Engine.Adapters.OpenStreetMap
         [Output("utmPoints", "Converted Nodes as Points.")]
         public static List<Point> ToUTMPoint(this List<Node> nodes)
         {
-            ConcurrentBag<Point> points = new ConcurrentBag<Point>();
-            Parallel.ForEach(nodes, node =>
+            //dictionary to ensure node order is maintained
+            ConcurrentDictionary<int, Point> pointDict = new ConcurrentDictionary<int, Point>();
+            Parallel.For(0, nodes.Count, n =>
             {
-                points.Add(ToUTMPoint(node.Latitude, node.Longitude));
+                pointDict.TryAdd(n,ToUTMPoint(nodes[n].Latitude, nodes[n].Longitude));
             });
-            return points.ToList();
+            return pointDict.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value).ToList(); ;
         }
         /***************************************************/
         [Description("Convert latitude and longitude to a Point in Universal Transverse Mercator coordinates.")]

--- a/OpenStreetMap_Engine/Convert/ToUTMPoint.cs
+++ b/OpenStreetMap_Engine/Convert/ToUTMPoint.cs
@@ -64,7 +64,11 @@ namespace BH.Engine.Adapters.OpenStreetMap
         [Output("utmPoint", "Converted Node as a Point.")]
         public static Point ToUTMPoint(this double lat, double lon, int gridZone = 0)
         {
-            Coordinate c = new Coordinate(lat, lon);
+            //EagerLoad sets which CoordinateSystems are calculated set all to false except UTM_MGRS
+            EagerLoad el = new EagerLoad(false);
+            el.UTM_MGRS = true;
+            el.Extensions.MGRS = false;
+            Coordinate c = new Coordinate(lat, lon,el);
             if (gridZone >= 1 && gridZone <= 60)
                 c.Lock_UTM_MGRS_Zone(gridZone);
             Point utmPoint = Geometry.Create.Point(c.UTM.Easting, c.UTM.Northing, 0);

--- a/OpenStreetMap_Engine/Convert/ToUTMPoint.cs
+++ b/OpenStreetMap_Engine/Convert/ToUTMPoint.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -36,7 +36,7 @@ namespace BH.Engine.Adapters.OpenStreetMap
         /***************************************************/
         /****           Public Methods                  ****/
         /***************************************************/
-        [Description("Convert an OpenStreetMap Node to a UTM Point.")]
+        [Description("Convert an OpenStreetMap Node to a Point in Universal Transverse Mercator coordinates.")]
         [Input("node", "OpenStreetMap Node to convert.")]
         [Output("utmPoint", "Converted Node as a Point.")]
         public static Point ToUTMPoint(this Node node)
@@ -44,7 +44,7 @@ namespace BH.Engine.Adapters.OpenStreetMap
             return ToUTMPoint(node.Latitude, node.Longitude);
         }
         /***************************************************/
-        [Description("Convert a collection of OpenStreetMap Nodes to UTM Points using parallel processing to improve performance.")]
+        [Description("Convert a collection of OpenStreetMap Nodes to a collection of Points in Universal Transverse Mercator coordinates using parallel processing.")]
         [Input("nodes", "OpenStreetMap Nodes to convert.")]
         [Output("utmPoints", "Converted Nodes as Points.")]
         public static List<Point> ToUTMPoint(this List<Node> nodes)

--- a/OpenStreetMap_Engine/Convert/ToUTMPoint.cs
+++ b/OpenStreetMap_Engine/Convert/ToUTMPoint.cs
@@ -57,10 +57,11 @@ namespace BH.Engine.Adapters.OpenStreetMap
             return points.ToList();
         }
         /***************************************************/
-        [Description("Convert latitude and longitude to universal transverse mercator.")]
-        [Input("lat", "Decimal latitude.")]
-        [Input("lon", "Decimal longitude.")]
-        [Output("double []", "Array of two doubles as easting and northing (x,y).")]
+        [Description("Convert latitude and longitude to a Point in Universal Transverse Mercator coordinates.")]
+        [Input("lat", "The latitude, in the range -90.0 to 90.0 with up to 7 decimal places.")]
+        [Input("lon", "The longitude, in the range -180.0 to 180.0 with up to 7 decimal places.")]
+        [Input("gridZone", "Optional Universal Transverse Mercator zone to allow locking conversion to a single zone.")]
+        [Output("utmPoint", "Converted Node as a Point.")]
         public static Point ToUTMPoint(this double lat, double lon, int gridZone = 0)
         {
             Coordinate c = new Coordinate(lat, lon);

--- a/OpenStreetMap_Engine/Convert/ToUTMPolyline.cs
+++ b/OpenStreetMap_Engine/Convert/ToUTMPolyline.cs
@@ -36,9 +36,9 @@ namespace BH.Engine.Adapters.OpenStreetMap
         /***************************************************/
         /****           Public Methods                  ****/
         /***************************************************/
-        [Description("Convert an OpenStreetMap Way to a UTM Polyline.")]
+        [Description("Convert an OpenStreetMap Way to a Polyline in Universal Transverse Mercator coordinates.")]
         [Input("way", "OpenStreetMap Way to convert.")]
-        [Input("gridZone", "Locks conversion to specified UTM zone.")]
+        [Input("gridZone", "Optional Universal Transverse Mercator zone to allow locking conversion to a single zone.")]
         [Output("utmPolyline", "Converted Way as a Polyline.")]
         public static Polyline ToUTMPolyline(this Way way, int gridZone = 0)
         {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #30 

Switched to `Parallel.ForEach` in `Convert.ToUTMPolyline`
Added a method to convert a collection of Nodes ToUTM points with  `Parallel.ForEach`
The conversion uses CoordinateSharp so further performance gains maybe possible by finding and switching to an alternative library or writing a custom converter.

### Test files
[Here to convert around 5000 nodes to points.](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/OpenStreetMap_Toolkit/%2366_ToUTMPolylineWithZoneOverride.gh?csf=1&web=1&e=as62nD)
Run before and after the build of this branch - depending on number of cores the before and after performance should be something like:
![2021-09-06_08-36-27](https://user-images.githubusercontent.com/6618854/132180151-357ccb45-df82-47d1-90e5-775f4b12fb3d.jpg)
![Capture](https://user-images.githubusercontent.com/6618854/132180164-2be37624-a6a1-47e8-aa21-852318f600b3.JPG)
Still slow but an improvement.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->